### PR TITLE
Fix cross-chain EGLD transfer

### DIFF
--- a/integrationtests/incomingSCR_test.go
+++ b/integrationtests/incomingSCR_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/multiversx/mx-chain-core-go/data/outport"
 	"github.com/multiversx/mx-chain-core-go/data/smartContractResult"
 	"github.com/multiversx/mx-chain-core-go/data/transaction"
+	vmcommon "github.com/multiversx/mx-chain-vm-common-go"
 	"github.com/stretchr/testify/require"
 
 	indexerData "github.com/multiversx/mx-chain-es-indexer-go/process/dataindexer"
@@ -86,6 +87,7 @@ func TestCrossChainTokensIndexingFromMainChain(t *testing.T) {
 
 	allTokens := getAllTokensIDs(tokens, nfts)
 	allTokens = append(allTokens, getAllNftIDs(nfts)...)
+	allTokens = append(allTokens, vmcommon.EGLDIdentifier)
 	genericResponse := &GenericResponse{}
 	err = esClient.DoMultiGet(context.Background(), allTokens, indexerData.TokensIndex, true, genericResponse)
 	require.Nil(t, err)
@@ -261,7 +263,7 @@ func getAllNftIDs(nfts []esNft) []string {
 
 func createMultiEsdtTransferData(tokens []esToken, nfts []esNft) []byte {
 	data := []byte(core.BuiltInFunctionMultiESDTNFTTransfer +
-		"@" + hex.EncodeToString(big.NewInt(int64(len(tokens)+len(nfts))).Bytes()))
+		"@" + hex.EncodeToString(big.NewInt(int64(len(tokens)+len(nfts)+1)).Bytes()))
 	for _, token := range tokens {
 		data = append(data, []byte(
 			"@"+hex.EncodeToString([]byte(token.Identifier))+
@@ -275,6 +277,10 @@ func createMultiEsdtTransferData(tokens []esToken, nfts []esNft) []byte {
 				"@"+hex.EncodeToString(big.NewInt(0).SetUint64(nft.Nonce).Bytes())+
 				"@"+hex.EncodeToString(nftDataBytes))...)
 	}
+	data = append(data, []byte(
+		"@"+hex.EncodeToString([]byte("EGLD-000000"))+
+			"@"+
+			"@"+hex.EncodeToString([]byte{0x01}))...)
 
 	return data
 }

--- a/integrationtests/testdata/incomingSCR/incoming-scr.json
+++ b/integrationtests/testdata/incomingSCR/incoming-scr.json
@@ -9,7 +9,7 @@
   "receiver": "erd1kzrfl2tztgzjpeedwec37c8npcr0a2ulzh9lhmj7xufyg23zcxuqxcqz0s",
   "senderShard": 4294967293,
   "receiverShard": 0,
-  "data": "TXVsdGlFU0RUTkZUVHJhbnNmZXJAMDNANTQ0YjRlMzEzODJkMzE2MTMyNjIzMzYzQEA3YkA1NDRiNGUzMTMyMmQzMTYzMzI2MjMzNjFAQDAxNGRANGU0NjU0MmQ2MTYyNjMzMTMyMzNAMDFAN2IyMjU0Nzk3MDY1MjIzYTMyMmMyMjU2NjE2Yzc1NjUyMjNhMzEyYzIyNTA3MjZmNzA2NTcyNzQ2OTY1NzMyMjNhMjI0ZDdhNDE3YTRkNjczZDNkMjIyYzIyNGQ2NTc0NjE0NDYxNzQ2MTIyM2E3YjIyNGU2ZjZlNjM2NTIyM2EzMTJjMjI0ZTYxNmQ2NTIyM2EyMjU0NmI1YTU1MjIyYzIyNDM3MjY1NjE3NDZmNzIyMjNhMjI1OTMzNGE2YzU5NTg1Mjc2NjM2NzNkM2QyMjJjMjI1MjZmNzk2MTZjNzQ2OTY1NzMyMjNhMzIzNTMwMzAyYzIyNDg2MTczNjgyMjNhNmU3NTZjNmMyYzIyNTU1MjQ5NzMyMjNhNmU3NTZjNmMyYzIyNDE3NDc0NzI2OTYyNzU3NDY1NzMyMjNhNmU3NTZjNmM3ZDJjMjI1MjY1NzM2NTcyNzY2NTY0MjIzYTZlNzU2YzZjN2Q=",
+  "data": "TXVsdGlFU0RUTkZUVHJhbnNmZXJAMDRANTQ0YjRlMzEzODJkMzE2MTMyNjIzMzYzQEA3YkA1NDRiNGUzMTMyMmQzMTYzMzI2MjMzNjFAQDAxNGRANGU0NjU0MmQ2MTYyNjMzMTMyMzNAMDFAN2IyMjU0Nzk3MDY1MjIzYTMyMmMyMjU2NjE2Yzc1NjUyMjNhMzEyYzIyNTA3MjZmNzA2NTcyNzQ2OTY1NzMyMjNhMjI0ZDdhNDE3YTRkNjczZDNkMjIyYzIyNGQ2NTc0NjE0NDYxNzQ2MTIyM2E3YjIyNGU2ZjZlNjM2NTIyM2EzMTJjMjI0ZTYxNmQ2NTIyM2EyMjU0NmI1YTU1MjIyYzIyNDM3MjY1NjE3NDZmNzIyMjNhMjI1OTMzNGE2YzU5NTg1Mjc2NjM2NzNkM2QyMjJjMjI1MjZmNzk2MTZjNzQ2OTY1NzMyMjNhMzIzNTMwMzAyYzIyNDg2MTczNjgyMjNhNmU3NTZjNmMyYzIyNTU1MjQ5NzMyMjNhNmU3NTZjNmMyYzIyNDE3NDc0NzI2OTYyNzU3NDY1NzMyMjNhNmU3NTZjNmM3ZDJjMjI1MjY1NzM2NTcyNzY2NTY0MjIzYTZlNzU2YzZjN2RANDU0NzRjNDQyZDMwMzAzMDMwMzAzMEBAMDE=",
   "prevTxHash": "",
   "originalTxHash": "",
   "callType": "0",
@@ -18,25 +18,30 @@
   "tokens": [
     "TKN18-1a2b3c",
     "TKN12-1c2b3a",
-    "NFT-abc123-01"
+    "NFT-abc123-01",
+    "EGLD-000000"
   ],
   "epoch": 0,
   "esdtValues": [
     "123",
     "333",
+    "1",
     "1"
   ],
   "esdtValuesNum": [
     1.23e-16,
     3.33e-16,
+    1e-18,
     1e-18
   ],
   "receivers": [
     "erd1kzrfl2tztgzjpeedwec37c8npcr0a2ulzh9lhmj7xufyg23zcxuqxcqz0s",
     "erd1kzrfl2tztgzjpeedwec37c8npcr0a2ulzh9lhmj7xufyg23zcxuqxcqz0s",
+    "erd1kzrfl2tztgzjpeedwec37c8npcr0a2ulzh9lhmj7xufyg23zcxuqxcqz0s",
     "erd1kzrfl2tztgzjpeedwec37c8npcr0a2ulzh9lhmj7xufyg23zcxuqxcqz0s"
   ],
   "receiversShardIDs": [
+    0,
     0,
     0,
     0

--- a/process/elasticproc/tokens/sovereignIndexTokensHandler.go
+++ b/process/elasticproc/tokens/sovereignIndexTokensHandler.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/multiversx/mx-chain-core-go/core"
 	"github.com/multiversx/mx-chain-core-go/data/esdt"
+	vmcommon "github.com/multiversx/mx-chain-vm-common-go"
 
 	"github.com/multiversx/mx-chain-es-indexer-go/data"
 	indexerdata "github.com/multiversx/mx-chain-es-indexer-go/process/dataindexer"
@@ -127,6 +128,10 @@ func (sit *sovereignIndexTokensHandler) serializeNewTokens(responseTokensInfo []
 }
 
 func formatToken(token data.ResponseTokenInfoDB) (data.TokenInfo, string) {
+	if token.ID == vmcommon.EGLDIdentifier {
+		return createEGLDTokenInfo(), token.ID
+	}
+
 	token.Source.OwnersHistory = nil
 	token.Source.Properties = nil
 
@@ -135,6 +140,16 @@ func formatToken(token data.ResponseTokenInfoDB) (data.TokenInfo, string) {
 		identifier = token.Source.Token // for tokens/collections
 	}
 	return token.Source, identifier
+}
+
+func createEGLDTokenInfo() data.TokenInfo {
+	return data.TokenInfo{
+		Name:        "EGLD",
+		Ticker:      "EGLD",
+		Token:       vmcommon.EGLDIdentifier,
+		NumDecimals: 18,
+		Type:        core.FungibleESDT,
+	}
 }
 
 // IsInterfaceNil returns true if there is no value under the interface


### PR DESCRIPTION
Index a default `EGLD-000000` token when a cross-chain egld transfer is sent